### PR TITLE
chore(ci): update workflows to accommodate pnpm

### DIFF
--- a/.github/workflows/prod-site-deploy.yaml
+++ b/.github/workflows/prod-site-deploy.yaml
@@ -21,16 +21,22 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: "10.9.0"
+          run_install: false
+
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 20
-          cache: "npm"
+          cache: "pnpm"
 
       - name: Install Dependencies
         run: |
-          npm install --global turbo@2.5
-          npm ci
+          pnpm i -g turbo@2.5
+          pnpm i
 
       - name: Build
         run: turbo run build

--- a/apps/site/src/index.html
+++ b/apps/site/src/index.html
@@ -20,7 +20,7 @@
     <main class="construction">
       <div class="construction__wrapper">
         <h1 class="construction__title">GKSS UNISA</h1>
-        <h2 class="construction__subtitle">🚧 Work in Progress 🚧</h2>
+        <h2 class="construction__subtitle">🚧 Work in Progress. YAY!!! 🚧</h2>
         <p class="construction__message">
           Check back soon for updates, in the mean time
           <a


### PR DESCRIPTION
This pull request updates the deployment workflow to use PNPM instead of NPM for dependency management and installation. The changes involve adding a step to install PNPM, switching the caching mechanism, and updating commands to use PNPM.

### Workflow updates for PNPM:

* [`.github/workflows/prod-site-deploy.yaml`](diffhunk://#diff-4fd6e61b1a99bbfb21986c734d5ca1c2a6c8e4388e22ff957746e8606213caa3R24-R39): Added a step to install PNPM (`pnpm/action-setup@v4`) with version `10.9.0`.
* [`.github/workflows/prod-site-deploy.yaml`](diffhunk://#diff-4fd6e61b1a99bbfb21986c734d5ca1c2a6c8e4388e22ff957746e8606213caa3R24-R39): Changed the dependency caching mechanism from `"npm"` to `"pnpm"`.
* [`.github/workflows/prod-site-deploy.yaml`](diffhunk://#diff-4fd6e61b1a99bbfb21986c734d5ca1c2a6c8e4388e22ff957746e8606213caa3R24-R39): Updated dependency installation commands to use PNPM (`pnpm i -g turbo@2.5` and `pnpm i`) instead of NPM.